### PR TITLE
infra(integration): Automatically Update Personal Main Branches conflict 미해결 오류 수정

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,4 +1,4 @@
-name: Inform updating personal main branches
+name: Automatically Update Personal Main Branches
 run-name: Updating Personal Main Branches on ${{ github.ref_name }}
 on:
   push:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -78,14 +78,15 @@ jobs:
               # Create a temporary branch from 'main' to test the merge
               git checkout -b temp-merge-branch $MAIN_BRANCH_SHA
 
-              MERGE_OUTPUT=$(git merge --no-commit --no-ff origin/$branch 2>&1 || true) # Both standard output and errors (2>&1) are redirected to the variable MERGE_OUTPUT
-              if echo "$MERGE_OUTPUT" | grep -q "CONFLICT"; then
-                # Capture the conflict files
-                CONFLICT_FILES=$(git diff --name-only --diff-filter=U)
+              MERGE_OUTPUT=$(git merge --no-commit --no-ff origin/$branch 2>&1)
+              MERGE_EXIT_CODE=$?
+
+              if [ "$MERGE_EXIT_CODE" -ne 0] || echo "$MERGE_OUTPUT" | grep -q "CONFLICT"; then
                 echo "Conflicts in branch $branch:"
+                git merge --abort || true
+                CONFLICT_FILES=$(git diff --name-only --diff-filter=U)
                 echo "$CONFLICT_FILES"
               else
-                # No conflicts but the branch cannot be fast-forwarded
                 echo "$branch" >> conflict_free_diverged_branches.txt
                 echo "Branch $branch has no conflict but cannot be fast-forwarded."
               fi


### PR DESCRIPTION
# 변경 사항

- 해당 워크플로우의 `Find branches that can be updated without conflicts` 스텝 이 비정상적 작동 하는 것을 수정
- 해당 스텝의 이상으로 `Merge Diverged Conflict-Free Branches` 스텝이 오류를 일으킴

# 참조

- Close #43 